### PR TITLE
An alternative implementation to speed up iterating successive `DcmList` elements using `seek_to`

### DIFF
--- a/dcmdata/include/dcmtk/dcmdata/dclist.h
+++ b/dcmdata/include/dcmtk/dcmdata/dclist.h
@@ -171,6 +171,10 @@ private:
     /// pointer to current node in list
     DcmListNode *currentNode;
 
+    /// the current absolute position that is maintained in order to avoid O(n) lookup
+    /// when essentially iterating the elements using `seek_to`
+    unsigned long currentAbsolutePosition;
+
     /// number of elements in list
     unsigned long cardinality;
  


### PR DESCRIPTION
Problem: Reading a real-world DICOM image was a bit slow, and simple profiling suggested that some 50% of the time (*) was spent in `DcmPixelSequence` essentially iterating a long list using successive calls to `DcmList::seek_to` (which has a random-access-like interface, but internally _iterates_ over a doubly linked list)

Solution: In `DcmList`, keep the current absolute position, essentially catering for O(1) access whenever going to the previous or the next element (NB: truly _random_ access is still O(n), though)

(*): the other 50% was spent decoding jpeg tiles, which is legit use of time of course

(cherry picked from commit 550bc9970ee4ec47b2aca2fc270651621a4b3bb4)